### PR TITLE
[TASK] Allow localization of grid column titles

### DIFF
--- a/Classes/Controller/Backend/PageModule/Renderer/SheetRenderer.php
+++ b/Classes/Controller/Backend/PageModule/Renderer/SheetRenderer.php
@@ -564,7 +564,7 @@ class SheetRenderer implements Renderable
             ];
 
             $columns[$fieldID] = [
-                'title' => $column->getTitle(),
+                'title' => static::getLanguageService()->sL($column->getTitle()),
                 'content' => $this->renderColumn(
                     $column,
                     $subElementPointer,

--- a/Classes/Controller/Backend/PageModule/Renderer/SheetRenderer.php
+++ b/Classes/Controller/Backend/PageModule/Renderer/SheetRenderer.php
@@ -564,7 +564,7 @@ class SheetRenderer implements Renderable
             ];
 
             $columns[$fieldID] = [
-                'title' => static::getLanguageService()->sL($column->getTitle()),
+                'title' => $this->localizedFFLabel($column->getTitle(), true),
                 'content' => $this->renderColumn(
                     $column,
                     $subElementPointer,


### PR DESCRIPTION
The localization of sheet columns with LLL: labels once was supported by the old templavoila extension, this patch brings back the original functionality