### PR TITLE
A few fixes to make editing DS in the backend work again

### DIFF
--- a/Classes/Controller/Backend/AdministrationModule/DataStructureEditor.php
+++ b/Classes/Controller/Backend/AdministrationModule/DataStructureEditor.php
@@ -168,7 +168,7 @@ class DataStructureEditor
             $array['rows'][$rowIndex]['buttons'] = [];
             $array['rows'][$rowIndex]['isInEditMode'] = $this->isModeEnabled(static::MODE_EDIT);
             $array['rows'][$rowIndex]['isInMappingMode'] = $this->isModeEnabled(static::MODE_MAPPING);
-            $array['rows'][$rowIndex]['isContainer'] = $value['type'] === 'array';
+            $array['rows'][$rowIndex]['isContainer'] = in_array($type, array('sc', 'co')) ;
             $array['rows'][$rowIndex]['type'] = $type;
             $array['rows'][$rowIndex]['key'] = $key;
             $array['rows'][$rowIndex]['icon'] = [
@@ -346,7 +346,7 @@ class DataStructureEditor
 //                        $rowCells['cmdLinks'] .= '<br />
 //                                <a class="btn btn-default btn-sm" href="' . $cancelUrl . '">' . static::getLanguageService()->getLL('buttonCancel') . '</a>';
                     }
-                } elseif ($mapOK && $value['type'] !== 'no_map' && empty($array['rows'][$rowIndex]['buttons'])) {
+                } elseif ($mapOK && $type !== 'no' && empty($array['rows'][$rowIndex]['buttons'])) {
                     $array['rows'][$rowIndex]['buttons'][] = [
                         'url' => $this->controller->getModuleUrl([
                                 'mapElPath' => $formPrefix . '[' . $key . ']',
@@ -394,7 +394,7 @@ class DataStructureEditor
 
             $array['rows'][$rowIndex]['form']['edit'] = $this->drawDataStructureMap_editItem($formPrefix, $key, $value);
 
-            if ($value['type'] === 'array') {
+            if (in_array($type, array('sc', 'co'))) {
                 if (!$this->mapElPath) {
                     $array['rows'][$rowIndex]['form']['create'] = [
                         'action' => $this->controller->getModuleUrl([
@@ -445,9 +445,9 @@ class DataStructureEditor
     public function drawDataStructureMap_editItem($formPrefix, $key, $value)
     {
         $return = [];
-
+        $type = $this->dsTypeInfo($value);
         if ($this->DS_element !== $formPrefix . '[' . $key . ']') {
-            if (!$this->mapElPath && ($value['type'] === 'array' || $value['type'] === 'section')) {
+            if (!$this->mapElPath && (in_array($type, array('sc', 'co')))) {
                 // todo: edit this
                 $addEditRows = '<tr class="bgColor4">
                 <td colspan="7">' .
@@ -556,6 +556,9 @@ class DataStructureEditor
      */
     private function dsTypeInfo($conf)
     {
+        if ($conf['type'] === 'array' && !empty($conf['section'])) {
+            return 'sc';
+        }
         if ($conf['tx_templavoila']['type'] === 'section') {
             return 'sc';
         }

--- a/Classes/Controller/Backend/AdministrationModule/DataStructureEditor.php
+++ b/Classes/Controller/Backend/AdministrationModule/DataStructureEditor.php
@@ -614,6 +614,9 @@ class DataStructureEditor
         /*
          * type select field
          */
+        if (isset($insertDataArray['section']) && !isset($insertDataArray['tx_templavoila']['type'])) {
+            $insertDataArray['tx_templavoila']['type'] = 'section';
+        }
         $array['input']['type'] = [
             'label' => 'Type',
             'html' => $this->renderTypeSelectField($formFieldName, $insertDataArray['tx_templavoila']['type'])

--- a/Classes/Controller/Backend/AdministrationModule/ElementController.php
+++ b/Classes/Controller/Backend/AdministrationModule/ElementController.php
@@ -745,7 +745,7 @@ class ElementController extends AbstractModuleController implements Configurable
                 unset($value['type'], $value['section']);
 
                 if ($value['tx_templavoila']['type'] === 'section') {
-                    $value['section'] = 1;
+                    $value['section'] = '1';
 
                     /*
                      * Whenever a section is created/updated and it does not have any children,

--- a/Classes/Controller/Backend/AdministrationModule/ElementController.php
+++ b/Classes/Controller/Backend/AdministrationModule/ElementController.php
@@ -688,6 +688,12 @@ class ElementController extends AbstractModuleController implements Configurable
         if (is_array($inDS)) {
             $this->convertTceFormStringToArrayRecursive($inDS);
 
+            //allow removing items from config, which would be prevented by merging old and new one
+            $configPath = str_replace(['[', ']'], ['/', ''], trim($DS_element, '[')) . '/TCEforms/config';
+            if (ArrayUtility::isValidPath($dataStructure, $configPath)) {
+                $dataStructure = ArrayUtility::removeByPath($dataStructure, $configPath);
+            }
+
             ArrayUtility::mergeRecursiveWithOverrule($dataStructure, $inDS);
 
             $this->streamlineStructureRecursive($dataStructure);

--- a/Classes/Controller/Backend/AdministrationModule/Renderer/ElementTypesRenderer.php
+++ b/Classes/Controller/Backend/AdministrationModule/Renderer/ElementTypesRenderer.php
@@ -110,11 +110,11 @@ class ElementTypesRenderer implements SingletonInterface
                 } else {
                     $eTypes = static::defaultEtypes();
                     $eType = $elArray[$key]['tx_templavoila']['eType'];
+                    $elArray[$key]['TCEforms']['label'] = $elArray[$key]['tx_templavoila']['title'];
                     switch ($eType) {
                         case 'text':
                             /* preserve previous config, if of the right kind */
                             if ($reset || ($elArray[$key]['TCEforms']['config']['type'] !== 'text')) {
-                                $elArray[$key]['TCEforms']['label'] = $elArray[$key]['tx_templavoila']['title'];
                                 $elArray[$key]['TCEforms']['config'] = $eTypes['eType'][$eType]['TCEforms']['config'];
                             }
 
@@ -126,7 +126,6 @@ class ElementTypesRenderer implements SingletonInterface
                         case 'rte':
                             /* preserve previous config, if of the right kind */
                             if ($reset || ($elArray[$key]['TCEforms']['config']['type'] !== 'text')) {
-                                $elArray[$key]['TCEforms']['label'] = $elArray[$key]['tx_templavoila']['title'];
                                 $elArray[$key]['TCEforms']['config'] = $eTypes['eType'][$eType]['TCEforms']['config'];
                             }
 
@@ -148,7 +147,6 @@ class ElementTypesRenderer implements SingletonInterface
                         case 'imagefixed':
                             /* preserve previous config, if of the right kind */
                             if ($reset || ($elArray[$key]['TCEforms']['config']['type'] !== 'group')) {
-                                $elArray[$key]['TCEforms']['label'] = $elArray[$key]['tx_templavoila']['title'];
                                 $elArray[$key]['TCEforms']['config'] = $eTypes['eType'][$eType]['TCEforms']['config'];
                             }
 
@@ -190,7 +188,6 @@ class ElementTypesRenderer implements SingletonInterface
                         case 'link':
                             /* preserve previous config, if of the right kind */
                             if ($reset || ($elArray[$key]['TCEforms']['config']['type'] !== 'input')) {
-                                $elArray[$key]['TCEforms']['label'] = $elArray[$key]['tx_templavoila']['title'];
                                 $elArray[$key]['TCEforms']['config'] = $eTypes['eType'][$eType]['TCEforms']['config'];
                             }
 
@@ -212,7 +209,6 @@ class ElementTypesRenderer implements SingletonInterface
                         case 'ce':
                             /* preserve previous config, if of the right kind */
                             if ($reset || ($elArray[$key]['TCEforms']['config']['type'] !== 'group')) {
-                                $elArray[$key]['TCEforms']['label'] = $elArray[$key]['tx_templavoila']['title'];
                                 $elArray[$key]['TCEforms']['config'] = $eTypes['eType'][$eType]['TCEforms']['config'];
                             }
 
@@ -231,7 +227,6 @@ class ElementTypesRenderer implements SingletonInterface
                         case 'int':
                             /* preserve previous config, if of the right kind */
                             if ($reset || ($elArray[$key]['TCEforms']['config']['type'] !== 'input')) {
-                                $elArray[$key]['TCEforms']['label'] = $elArray[$key]['tx_templavoila']['title'];
                                 $elArray[$key]['TCEforms']['config'] = $eTypes['eType'][$eType]['TCEforms']['config'];
                             }
                             if ($reset) {
@@ -242,7 +237,6 @@ class ElementTypesRenderer implements SingletonInterface
                         case 'select':
                             /* preserve previous config, if of the right kind */
                             if ($reset || ($elArray[$key]['TCEforms']['config']['type'] !== 'select')) {
-                                $elArray[$key]['TCEforms']['label'] = $elArray[$key]['tx_templavoila']['title'];
                                 $elArray[$key]['TCEforms']['config'] = $eTypes['eType'][$eType]['TCEforms']['config'];
                             }
                             if ($reset) {
@@ -252,7 +246,6 @@ class ElementTypesRenderer implements SingletonInterface
                         case 'check':
                             /* preserve previous config, if of the right kind */
                             if ($reset || ($elArray[$key]['TCEforms']['config']['type'] !== 'check')) {
-                                $elArray[$key]['TCEforms']['label'] = $elArray[$key]['tx_templavoila']['title'];
                                 $elArray[$key]['TCEforms']['config'] = $eTypes['eType'][$eType]['TCEforms']['config'];
                             }
                             if ($reset) {
@@ -264,7 +257,6 @@ class ElementTypesRenderer implements SingletonInterface
                         case 'input_g':
                             /* preserve previous config, if of the right kind */
                             if ($reset || ($elArray[$key]['TCEforms']['config']['type'] !== 'input')) {
-                                $elArray[$key]['TCEforms']['label'] = $elArray[$key]['tx_templavoila']['title'];
                                 $elArray[$key]['TCEforms']['config'] = $eTypes['eType'][$eType]['TCEforms']['config'];
                             }
 
@@ -335,7 +327,6 @@ class ElementTypesRenderer implements SingletonInterface
                         default:
                             /* preserve previous config, if of the right kind */
                             if ($reset || ($elArray[$key]['TCEforms']['config']['type'] !== 'text')) {
-                                $elArray[$key]['TCEforms']['label'] = $elArray[$key]['tx_templavoila']['title'];
                                 $elArray[$key]['TCEforms']['config'] = $eTypes['eType'][$eType]['TCEforms']['config'];
                             }
                             if ($reset || !trim($elArray[$key]['tx_templavoila']['TypoScript'])) {

--- a/Classes/Controller/Backend/AdministrationModule/Renderer/ElementTypesRenderer.php
+++ b/Classes/Controller/Backend/AdministrationModule/Renderer/ElementTypesRenderer.php
@@ -86,6 +86,10 @@ class ElementTypesRenderer implements SingletonInterface
             /* ---------------------------------------------------------------------- */
             if ($elArray[$key]['type'] === 'array') { // If array, then unset:
                 unset($elArray[$key]['tx_templavoila']['sample_data']);
+                if (isset($elArray[$key]['tx_templavoila']['title'])) {
+                    //containers have their title there
+                    $elArray[$key]['title'] = $elArray[$key]['tx_templavoila']['title'];
+                }
             } else { // Only non-arrays can have configuration (that is elements and attributes)
 
                 // Getting some information about the HTML content (eg. images width/height if applicable)


### PR DESCRIPTION
When editing TV datastructures in the TYPO3 backend, things get broken or do not work correctly.

Here are some patches that improve datastructures modification.